### PR TITLE
shift-double-click for markers

### DIFF
--- a/client/map.coffee
+++ b/client/map.coffee
@@ -108,7 +108,7 @@ emit = ($item, item) ->
       if e.originalEvent.shiftKey
         e.originalEvent.stopPropagation()
         new L.marker(e.latlng).addTo(map)
-        item.text += "\n#{e.latlng.lat}, #{e.latlng.lng}"
+        item.text += "\n#{e.latlng.lat.toFixed 7}, #{e.latlng.lng.toFixed 7}"
         update()
 
 

--- a/client/map.coffee
+++ b/client/map.coffee
@@ -97,8 +97,20 @@ emit = ($item, item) ->
 
     map = L.map(mapId)
 
-    # disable double click zoom - so we can use double click to start edit
+    update = ->
+      wiki.pageHandler.put $item.parents('.page:first'),
+        type: 'edit',
+        id: item.id,
+        item: item
+
     map.doubleClickZoom.disable()
+    map.on 'dblclick', (e) ->
+      if e.originalEvent.shiftKey
+        e.originalEvent.stopPropagation()
+        new L.marker(e.latlng).addTo(map)
+        item.text += "\n#{e.latlng.lat}, #{e.latlng.lng}"
+        update()
+
 
     # select tiles, default to OSM
     tile = item.tile || "http://{s}.tile.osm.org/{z}/{x}/{y}.png"

--- a/pages/about-map-plugin
+++ b/pages/about-map-plugin
@@ -29,6 +29,11 @@
     },
     {
       "type": "paragraph",
+      "id": "76d50ac0185b709d",
+      "text": "Shift-double-click to add a marker at a map location."
+    },
+    {
+      "type": "paragraph",
       "id": "673860db5b7c1d3b",
       "text": "A line starting with coordinates describes a marker. Text after the marker become the marker's popup label."
     },
@@ -576,6 +581,27 @@
       },
       "after": "9e29c3aaae504fcb",
       "date": 1467749929312
+    },
+    {
+      "type": "add",
+      "id": "76d50ac0185b709d",
+      "item": {
+        "type": "paragraph",
+        "id": "76d50ac0185b709d",
+        "text": "Shift-double-click to add markers without opening the editor."
+      },
+      "after": "0afb0c6bd45cb7ed",
+      "date": 1467904288251
+    },
+    {
+      "type": "edit",
+      "id": "76d50ac0185b709d",
+      "item": {
+        "type": "paragraph",
+        "id": "76d50ac0185b709d",
+        "text": "Shift-double-click to add a marker at a map location."
+      },
+      "date": 1467904348593
     }
   ]
 }


### PR DESCRIPTION
Work in progress for #11. 

![image](https://cloud.githubusercontent.com/assets/12127/16644755/0d2c4f54-43d4-11e6-97de-9a46ec069df7.png)

Note that each shift-double-click adds an action to the journal. Earlier versions with fewer markers can be recalled from history.
